### PR TITLE
Fix addOscillator and theme switching "doubling up" issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,13 @@
 import DroneSynth from "./components/DroneSynth";
+import ThemeControls from "./components/ThemeControls";
 import { AudioContextProvider } from "./context/audio";
 
-import { useDarkMode } from "./hooks/useDarkMode";
-
 function App() {
-  const [isDarkMode, toggleDarkMode] = useDarkMode();
-
   return (
     <AudioContextProvider>
       <div className="text-pink-900 dark:text-sky-300">
         <div className="flex space-x-2 my-5 ml-5">
-          <button
-            className="border-2 rounded-md border-pink-500 dark:border-sky-300 px-2 py-1"
-            onClick={toggleDarkMode}
-          >
-            Theme: {isDarkMode ? "Dark" : "Light"}
-          </button>
+          <ThemeControls />
         </div>
         <div className="m-4">
           <DroneSynth />

--- a/src/components/AutoFilter.tsx
+++ b/src/components/AutoFilter.tsx
@@ -6,7 +6,7 @@ import { MutableRefObject, useState } from "react";
 import OptionsSelector from "./OptionsSelector";
 
 interface AutoFilterProps {
-  filter: MutableRefObject<Tone.AutoFilter> | null;
+  filter: MutableRefObject<Tone.AutoFilter>;
 }
 
 function AutoFilter({ filter }: AutoFilterProps) {

--- a/src/components/AutoFilter.tsx
+++ b/src/components/AutoFilter.tsx
@@ -17,7 +17,7 @@ function AutoFilter({ filter }: AutoFilterProps) {
   const [type, setType] = useState<BiquadFilterType>("highpass");
   const [oscillatorType, setOscillatorType] = useState<OscillatorType>("sine");
 
-  filter?.current?.set({
+  filter.current.set({
     baseFrequency,
     depth,
     frequency,

--- a/src/components/BitCrusher.tsx
+++ b/src/components/BitCrusher.tsx
@@ -12,7 +12,7 @@ function BitCrusher({ bitCrusher }: BitCrusherProps) {
   const [bits, setBits] = useState(5);
   const [wet, setWet] = useState(0);
 
-  bitCrusher?.current?.set({
+  bitCrusher.current.set({
     bits,
     wet,
   });

--- a/src/components/BitCrusher.tsx
+++ b/src/components/BitCrusher.tsx
@@ -5,7 +5,7 @@ import Slider from "./Slider";
 import { MutableRefObject, useState } from "react";
 
 interface BitCrusherProps {
-  bitCrusher: MutableRefObject<Tone.BitCrusher> | null;
+  bitCrusher: MutableRefObject<Tone.BitCrusher>;
 }
 
 function BitCrusher({ bitCrusher }: BitCrusherProps) {

--- a/src/components/Chebyshev.tsx
+++ b/src/components/Chebyshev.tsx
@@ -12,7 +12,7 @@ function Chebyshev({ chebyshev }: ChebyshevProps) {
   const [order, setOrder] = useState(1);
   const [wet, setWet] = useState(0);
 
-  chebyshev?.current?.set({
+  chebyshev.current.set({
     order,
     wet,
   });

--- a/src/components/Chebyshev.tsx
+++ b/src/components/Chebyshev.tsx
@@ -5,7 +5,7 @@ import Slider from "./Slider";
 import { MutableRefObject, useState } from "react";
 
 interface ChebyshevProps {
-  chebyshev: MutableRefObject<Tone.Chebyshev> | null;
+  chebyshev: MutableRefObject<Tone.Chebyshev>;
 }
 
 function Chebyshev({ chebyshev }: ChebyshevProps) {

--- a/src/components/Delay.tsx
+++ b/src/components/Delay.tsx
@@ -5,7 +5,7 @@ import Slider from "./Slider";
 import { MutableRefObject, useState } from "react";
 
 interface DelayProps {
-  delay: MutableRefObject<Tone.FeedbackDelay | null>;
+  delay: MutableRefObject<Tone.FeedbackDelay>;
 }
 
 function Delay({ delay }: DelayProps) {

--- a/src/components/Delay.tsx
+++ b/src/components/Delay.tsx
@@ -13,7 +13,7 @@ function Delay({ delay }: DelayProps) {
   const [feedback, setFeedback] = useState(0.95);
   const [wet, setWet] = useState(0);
 
-  delay?.current?.set({
+  delay.current.set({
     delayTime: time,
     feedback: feedback,
     wet: wet,

--- a/src/components/DroneSynth.tsx
+++ b/src/components/DroneSynth.tsx
@@ -21,6 +21,8 @@ import { useReverb } from "../hooks/useReverb";
 
 import { usePolysynths } from "../hooks/usePolysynths";
 
+import { useEffect } from "react";
+
 function DroneSynth() {
   const recorder = useRecorder();
 
@@ -32,7 +34,7 @@ function DroneSynth() {
   const afterFilter = useAutoFilter();
   const compressor = new Tone.Compressor(-30, 3);
 
-  const mainAudioEffectsBus = useAudioEffectsBus(recorder.current, [
+  const effects = [
     beforeFilter?.current,
     bitCrusher?.current,
     chebyshev?.current,
@@ -40,13 +42,24 @@ function DroneSynth() {
     reverb?.current,
     afterFilter?.current,
     compressor,
+  ];
+
+  const mainAudioEffectsBus = useAudioEffectsBus(recorder.current, [
+    bitCrusher?.current,
+    chebyshev?.current,
   ]);
 
-  const polysynths = usePolysynths(2);
+  useEffect(() => {
+    if (recorder.current) {
+      Tone.getDestination().connect(recorder.current);
+    }
+  }, [recorder]);
 
-  polysynths.forEach((polysynth) => {
-    polysynth.connect(mainAudioEffectsBus.current);
-  });
+  // const polysynths = usePolysynths(2);
+
+  // polysynths.forEach((polysynth) => {
+  //   polysynth.connect(mainAudioEffectsBus.current);
+  // });
 
   return (
     <div className="dark:text-sky-300">
@@ -62,7 +75,7 @@ function DroneSynth() {
           <EffectsBusSendControl bus={mainAudioEffectsBus} />
         </Effects>
 
-        <PolySynths polysynths={polysynths} />
+        {/* <PolySynths polysynths={polysynths} /> */}
         <Oscillators bus={mainAudioEffectsBus} />
       </div>
     </div>

--- a/src/components/DroneSynth.tsx
+++ b/src/components/DroneSynth.tsx
@@ -48,7 +48,9 @@ function DroneSynth() {
     beforeFilter.current,
     bitCrusher.current,
     chebyshev.current,
+    delay.current,
     afterFilter.current,
+    compressor,
   ]);
 
   useEffect(() => {

--- a/src/components/DroneSynth.tsx
+++ b/src/components/DroneSynth.tsx
@@ -52,11 +52,11 @@ function DroneSynth() {
     }
   }, [recorder]);
 
-  // const polysynths = usePolysynths(2);
+  const polysynths = usePolysynths(2);
 
-  // polysynths.forEach((polysynth) => {
-  //   polysynth.connect(mainAudioEffectsBus.current);
-  // });
+  polysynths.forEach((polysynth) => {
+    polysynth.connect(mainAudioEffectsBus.current);
+  });
 
   return (
     <div className="dark:text-sky-300">
@@ -72,7 +72,7 @@ function DroneSynth() {
           <EffectsBusSendControl bus={mainAudioEffectsBus} />
         </Effects>
 
-        {/* <PolySynths polysynths={polysynths} /> */}
+        <PolySynths polysynths={polysynths} />
         <Oscillators bus={mainAudioEffectsBus} />
       </div>
     </div>

--- a/src/components/DroneSynth.tsx
+++ b/src/components/DroneSynth.tsx
@@ -35,23 +35,16 @@ function DroneSynth() {
   const compressor = new Tone.Compressor(-30, 3);
 
   const effects = [
-    beforeFilter?.current,
-    bitCrusher?.current,
-    chebyshev?.current,
-    delay?.current,
-    reverb?.current,
-    afterFilter?.current,
-    compressor,
-  ];
-
-  const mainAudioEffectsBus = useAudioEffectsBus([
     beforeFilter.current,
     bitCrusher.current,
     chebyshev.current,
     delay.current,
     afterFilter.current,
+    reverb.current,
     compressor,
-  ]);
+  ];
+
+  const mainAudioEffectsBus = useAudioEffectsBus(effects);
 
   useEffect(() => {
     if (recorder.current) {

--- a/src/components/DroneSynth.tsx
+++ b/src/components/DroneSynth.tsx
@@ -44,9 +44,11 @@ function DroneSynth() {
     compressor,
   ];
 
-  const mainAudioEffectsBus = useAudioEffectsBus(recorder.current, [
-    bitCrusher?.current,
-    chebyshev?.current,
+  const mainAudioEffectsBus = useAudioEffectsBus([
+    beforeFilter.current,
+    bitCrusher.current,
+    chebyshev.current,
+    afterFilter.current,
   ]);
 
   useEffect(() => {

--- a/src/components/Reverb.tsx
+++ b/src/components/Reverb.tsx
@@ -5,7 +5,7 @@ import Slider from "./Slider";
 import { MutableRefObject, useState } from "react";
 
 interface ReverbProps {
-  reverb: MutableRefObject<Tone.Freeverb> | null;
+  reverb: MutableRefObject<Tone.Freeverb>;
 }
 
 function Reverb({ reverb }: ReverbProps) {

--- a/src/components/Reverb.tsx
+++ b/src/components/Reverb.tsx
@@ -12,7 +12,7 @@ function Reverb({ reverb }: ReverbProps) {
   const [roomSize, setRoomSize] = useState(0.95);
   const [wet, setWet] = useState(0);
 
-  reverb?.current?.set({
+  reverb.current.set({
     roomSize,
     wet,
   });

--- a/src/components/ThemeControls.tsx
+++ b/src/components/ThemeControls.tsx
@@ -1,0 +1,16 @@
+import { useDarkMode } from "../hooks/useDarkMode";
+
+function ThemeControls() {
+  const [isDarkMode, toggleDarkMode] = useDarkMode();
+
+  return (
+    <button
+      className="border-2 rounded-md border-pink-500 dark:border-sky-300 px-2 py-1"
+      onClick={toggleDarkMode}
+    >
+      Theme: {isDarkMode ? "Dark" : "Light"}
+    </button>
+  );
+}
+
+export default ThemeControls;

--- a/src/hooks/useAudioEffectsBus.ts
+++ b/src/hooks/useAudioEffectsBus.ts
@@ -12,21 +12,30 @@ import { AudioEffect } from "../types/AudioEffect";
 
 export function useAudioEffectsBus(
   recorder: Tone.Recorder,
-  audioEffects: (AudioEffect | null)[]
+  audioEffects: AudioEffect[]
 ) {
   const mainAudioEffectsBus = useRef<Tone.Channel>(
     new Tone.Channel({ volume: -10, channelCount: 2 })
   );
 
   const updateAudioEffects = useCallback(() => {
-    if (!audioEffects.includes(null)) {
-      mainAudioEffectsBus.current.chain(
-        ...(audioEffects as AudioEffect[]),
-        Tone.getDestination(),
-        recorder
-      );
+    // mainAudioEffectsBus.current.disconnect();
+
+    for (let i = 0; i < audioEffects.length; i++) {
+      if (i === 0) {
+        mainAudioEffectsBus.current.connect(audioEffects[i]);
+      } else {
+        audioEffects[i - 1]?.connect(audioEffects[i]);
+      }
     }
-  }, [audioEffects, recorder]);
+    audioEffects[audioEffects.length - 1]?.connect(Tone.getDestination());
+
+    // mainAudioEffectsBus.current.chain(
+    //   ...(audioEffects as AudioEffect[]),
+    //   Tone.getDestination(),
+    //   recorder
+    // );
+  }, [audioEffects]);
 
   useEffect(() => {
     updateAudioEffects();

--- a/src/hooks/useAudioEffectsBus.ts
+++ b/src/hooks/useAudioEffectsBus.ts
@@ -10,10 +10,7 @@ import * as Tone from "tone";
 import { useCallback, useEffect, useRef } from "react";
 import { AudioEffect } from "../types/AudioEffect";
 
-export function useAudioEffectsBus(
-  recorder: Tone.Recorder,
-  audioEffects: AudioEffect[]
-) {
+export function useAudioEffectsBus(audioEffects: AudioEffect[]) {
   const mainAudioEffectsBus = useRef<Tone.Channel>(
     new Tone.Channel({ volume: -10, channelCount: 2 })
   );

--- a/src/hooks/useAudioEffectsBus.ts
+++ b/src/hooks/useAudioEffectsBus.ts
@@ -16,22 +16,7 @@ export function useAudioEffectsBus(audioEffects: AudioEffect[]) {
   );
 
   const updateAudioEffects = useCallback(() => {
-    // mainAudioEffectsBus.current.disconnect();
-
-    for (let i = 0; i < audioEffects.length; i++) {
-      if (i === 0) {
-        mainAudioEffectsBus.current.connect(audioEffects[i]);
-      } else {
-        audioEffects[i - 1]?.connect(audioEffects[i]);
-      }
-    }
-    audioEffects[audioEffects.length - 1]?.connect(Tone.getDestination());
-
-    // mainAudioEffectsBus.current.chain(
-    //   ...(audioEffects as AudioEffect[]),
-    //   Tone.getDestination(),
-    //   recorder
-    // );
+    mainAudioEffectsBus.current.chain(...audioEffects, Tone.getDestination());
   }, [audioEffects]);
 
   useEffect(() => {

--- a/src/hooks/useAutoFilter.ts
+++ b/src/hooks/useAutoFilter.ts
@@ -1,26 +1,21 @@
 import * as Tone from "tone";
-import { useEffect, useRef, MutableRefObject } from "react";
+import { useEffect, useRef } from "react";
 
 export function useAutoFilter() {
   const filter = useRef<Tone.AutoFilter>(
-    null
-  ) as MutableRefObject<Tone.AutoFilter>;
-
-  useEffect(() => {
-    filter.current = new Tone.AutoFilter({
+    new Tone.AutoFilter({
       baseFrequency: 300,
       octaves: 1,
       frequency: 4,
       type: "sine",
       depth: 1,
       wet: 1,
-    }).start();
+    })
+  );
 
+  useEffect(() => {
+    filter.current.start();
     filter.current.set({ filter: { type: "highpass" } });
-
-    return () => {
-      filter.current.dispose();
-    };
   }, []);
 
   return filter;

--- a/src/hooks/useBitCrusher.ts
+++ b/src/hooks/useBitCrusher.ts
@@ -1,20 +1,12 @@
 import * as Tone from "tone";
-import { useEffect, useRef, MutableRefObject } from "react";
+import { useRef } from "react";
 
 export function useBitCrusher() {
   const bitCrusher = useRef<Tone.BitCrusher>(
-    null
-  ) as MutableRefObject<Tone.BitCrusher>;
-
-  useEffect(() => {
-    bitCrusher.current = new Tone.BitCrusher({
+    new Tone.BitCrusher({
       bits: 5,
-    });
-
-    return () => {
-      bitCrusher.current.dispose();
-    };
-  }, []);
+    })
+  );
 
   return bitCrusher;
 }

--- a/src/hooks/useChebyshev.ts
+++ b/src/hooks/useChebyshev.ts
@@ -1,21 +1,13 @@
 import * as Tone from "tone";
-import { useEffect, useRef, MutableRefObject } from "react";
+import { useRef } from "react";
 
 export function useChebyshev() {
   const chebyshev = useRef<Tone.Chebyshev>(
-    null
-  ) as MutableRefObject<Tone.Chebyshev>;
-
-  useEffect(() => {
-    chebyshev.current = new Tone.Chebyshev({
+    new Tone.Chebyshev({
       order: 1,
       wet: 0,
-    });
-
-    return () => {
-      chebyshev.current.dispose();
-    };
-  }, []);
+    })
+  );
 
   return chebyshev;
 }

--- a/src/hooks/useDelay.ts
+++ b/src/hooks/useDelay.ts
@@ -1,23 +1,15 @@
 import * as Tone from "tone";
-import { useEffect, useRef, MutableRefObject } from "react";
+import { useRef } from "react";
 
 export function useDelay() {
   const delay = useRef<Tone.FeedbackDelay>(
-    null
-  ) as MutableRefObject<Tone.FeedbackDelay>;
-
-  useEffect(() => {
-    delay.current = new Tone.FeedbackDelay({
+    new Tone.FeedbackDelay({
       delayTime: 1,
       feedback: 0.95,
       maxDelay: 10,
       wet: 0,
-    });
-
-    return () => {
-      delay.current.dispose();
-    };
-  }, []);
+    })
+  );
 
   return delay;
 }

--- a/src/hooks/useReverb.ts
+++ b/src/hooks/useReverb.ts
@@ -1,20 +1,14 @@
 import * as Tone from "tone";
-import { useEffect, useRef, MutableRefObject } from "react";
+import { useRef } from "react";
 
 export function useReverb() {
-  const reverb = useRef<Tone.Freeverb>(null) as MutableRefObject<Tone.Freeverb>;
-
-  useEffect(() => {
-    reverb.current = new Tone.Freeverb({
+  const reverb = useRef<Tone.Freeverb>(
+    new Tone.Freeverb({
       dampening: 1000,
       roomSize: 0.95,
       wet: 0,
-    });
-
-    return () => {
-      reverb.current.dispose();
-    };
-  }, []);
+    })
+  );
 
   return reverb;
 }


### PR DESCRIPTION
When switching themes or adding an oscillator, the oscillators would start to harmonically distort, likely because of additional object creation and effects bus connections. By initializing the effects' refs as their default Tone.js objects instead of null, we can remove the null check from `src/hooks/useAudioEffectsBus.ts` and avoid this issue on oscillator add. 

We avoid the issue on theme switching by moving that logic in its own component and out of the root App.tsx level.