### PR TITLE
refactor: add WaveformType to fix type confusion

### DIFF
--- a/e2e/fixtures/presetData.ts
+++ b/e2e/fixtures/presetData.ts
@@ -90,7 +90,7 @@ export const testPreset: Preset = {
         Q: 1,
         wet: 0,
         type: "lowpass",
-        oscillatorType: "sine",
+        waveform: "sine",
       },
       bitCrusher: {
         bits: 4,

--- a/src/components/AutoFilter.test.tsx
+++ b/src/components/AutoFilter.test.tsx
@@ -69,7 +69,7 @@ describe("AutoFilter", () => {
         Q: 1,
         wet: 0,
         type: "highpass",
-        oscillatorType: "sine",
+        waveform: "sine",
       });
     });
 
@@ -99,7 +99,7 @@ describe("AutoFilter", () => {
         Q: 3,
         wet: 0.7,
         type: "lowpass",
-        oscillatorType: "square",
+        waveform: "square",
       };
 
       // Set new parameters wrapped in act
@@ -183,7 +183,7 @@ describe("AutoFilter", () => {
           Q: 3,
           wet: 0.7,
           type: "lowpass",
-          oscillatorType: "square",
+          waveform: "square",
         });
       });
 
@@ -197,7 +197,7 @@ describe("AutoFilter", () => {
           Q: 5,
           wet: 0.9,
           type: "bandpass",
-          oscillatorType: "triangle",
+          waveform: "triangle",
         });
       });
 
@@ -205,7 +205,7 @@ describe("AutoFilter", () => {
         const finalParams = handle.getParams();
         expect(finalParams?.baseFrequency).toBe(800);
         expect(finalParams?.type).toBe("bandpass");
-        expect(finalParams?.oscillatorType).toBe("triangle");
+        expect(finalParams?.waveform).toBe("triangle");
       });
     });
   });

--- a/src/components/AutoFilter.tsx
+++ b/src/components/AutoFilter.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, useImperativeHandle, useRef } from "react";
 import OptionsSelector from "./OptionsSelector";
 import { AutoFilterHandle, AutoFilterParams } from "../types/AutoFilterParams";
 import { useRampedParameter } from "../hooks/useRampedParameter";
+import { WaveformType } from "../types/OscillatorParams";
 
 interface AutoFilterProps {
   filter: React.RefObject<Tone.AutoFilter>;
@@ -21,7 +22,7 @@ function AutoFilter({ filter, ref, onParameterChange }: AutoFilterProps) {
   const [Q, setQ] = useState(1);
   const [wet, setWet] = useState(0);
   const [type, setType] = useState<BiquadFilterType>("highpass");
-  const [oscillatorType, setOscillatorType] = useState<OscillatorType>("sine");
+  const [waveform, setWaveform] = useState<WaveformType>("sine");
 
   // Keep a ref with current state values for imperative access
   const paramsRef = useRef<AutoFilterParams>({
@@ -32,7 +33,7 @@ function AutoFilter({ filter, ref, onParameterChange }: AutoFilterProps) {
     Q,
     wet,
     type,
-    oscillatorType,
+    waveform,
   });
 
   // Update ref whenever state changes
@@ -45,9 +46,9 @@ function AutoFilter({ filter, ref, onParameterChange }: AutoFilterProps) {
       Q,
       wet,
       type,
-      oscillatorType,
+      waveform,
     };
-  }, [baseFrequency, depth, frequency, rolloff, Q, wet, type, oscillatorType]);
+  }, [baseFrequency, depth, frequency, rolloff, Q, wet, type, waveform]);
 
   // Smooth ramped parameter updates (prevents clicking)
   // Type assertions needed for AutoFilter's Frequency types
@@ -81,7 +82,7 @@ function AutoFilter({ filter, ref, onParameterChange }: AutoFilterProps) {
       setQ(params.Q);
       setWet(params.wet);
       setType(params.type);
-      setOscillatorType(params.oscillatorType);
+      setWaveform(params.waveform);
     },
   }));
 
@@ -98,10 +99,10 @@ function AutoFilter({ filter, ref, onParameterChange }: AutoFilterProps) {
   useEffect(() => {
     if (filter.current) {
       filter.current.filter.type = type;
-      filter.current.type = oscillatorType;
+      filter.current.type = waveform;
       filter.current.filter.rolloff = rolloff;
     }
-  }, [filter, type, oscillatorType, rolloff]);
+  }, [filter, type, waveform, rolloff]);
 
   return (
     <div className="sm:place-items-center sm:border-2 sm:rounded sm:border-pink-500 dark:sm:border-sky-300 p-5">
@@ -197,12 +198,12 @@ function AutoFilter({ filter, ref, onParameterChange }: AutoFilterProps) {
           useDropdownOnSmall={true}
           label="Rolloff"
         />
-        <OptionsSelector<OscillatorType>
+        <OptionsSelector<WaveformType>
           handleChange={(e) => {
-            setOscillatorType(e.target.value as OscillatorType);
+            setWaveform(e.target.value as WaveformType);
             onParameterChange?.();
           }}
-          value={oscillatorType}
+          value={waveform}
           options={["sine", "square", "triangle", "sawtooth"]}
           useDropdownOnSmall={true}
           label="Wave"

--- a/src/components/ModulationLFO.tsx
+++ b/src/components/ModulationLFO.tsx
@@ -4,16 +4,17 @@ import { useDebounceCallback } from "usehooks-ts";
 import Slider from "./Slider";
 import OptionsSelector from "./OptionsSelector";
 import { LFOPolarityMode } from "../types/ModulationMatrixParams";
+import { WaveformType } from "../types/OscillatorParams";
 
 interface ModulationLFOProps {
   lfo: Tone.LFO;
   lfoIndex: number;
   initialFrequency?: number;
-  initialType?: OscillatorType;
+  initialType?: WaveformType;
   initialAmplitude?: number;
   initialPolarityMode?: LFOPolarityMode;
   onFrequencyChange?: (frequency: number) => void;
-  onTypeChange?: (type: OscillatorType) => void;
+  onTypeChange?: (type: WaveformType) => void;
   onAmplitudeChange?: (amplitude: number) => void;
   onPolarityModeChange?: (mode: LFOPolarityMode) => void;
   onParameterChange?: () => void;
@@ -33,7 +34,7 @@ function ModulationLFO({
   onParameterChange,
 }: ModulationLFOProps) {
   const [frequency, setFrequency] = useState(initialFrequency);
-  const [type, setType] = useState<OscillatorType>(initialType);
+  const [type, setType] = useState<WaveformType>(initialType);
   const [amplitude, setAmplitude] = useState(initialAmplitude);
   const [polarityMode, setPolarityMode] = useState<LFOPolarityMode>(initialPolarityMode);
 
@@ -117,9 +118,9 @@ function ModulationLFO({
             persistAmplitude(newAmp);
           }}
         />
-        <OptionsSelector<OscillatorType>
+        <OptionsSelector<WaveformType>
           handleChange={(e) => {
-            const newType = e.target.value as OscillatorType;
+            const newType = e.target.value as WaveformType;
             setType(newType);
             onTypeChange?.(newType);
             onParameterChange?.();

--- a/src/components/OptionsSelector.tsx
+++ b/src/components/OptionsSelector.tsx
@@ -1,13 +1,13 @@
 import * as Tone from "tone";
 import { clsx } from "clsx";
 import { useId } from "react";
-import { OscillatorType as OscTypeEnum } from "../types/OscillatorParams";
+import { OscillatorType, WaveformType } from "../types/OscillatorParams";
 
 type OptionType =
-  | OscillatorType
+  | WaveformType
   | BiquadFilterType
   | Tone.FilterRollOff
-  | OscTypeEnum;
+  | OscillatorType;
 
 interface OptionsSelectorProps<T extends OptionType> {
   handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;

--- a/src/components/Oscillator.tsx
+++ b/src/components/Oscillator.tsx
@@ -9,7 +9,7 @@ import { useState, useImperativeHandle, useRef, useEffect } from "react";
 
 import { useAudioContext } from "../hooks/useAudioContext";
 import { useKeyDown } from "../hooks/useKeyDown";
-import { OscillatorHandle, OscillatorParams } from "../types/OscillatorParams";
+import { OscillatorHandle, OscillatorParams, WaveformType } from "../types/OscillatorParams";
 import { DEFAULT_OSCILLATOR_PARAMS } from "../utils/presetDefaults";
 
 interface OscillatorProps {
@@ -70,7 +70,7 @@ function Oscillator({
   const [frequency, setFrequency] = useState(
     DEFAULT_OSCILLATOR_PARAMS.frequency
   );
-  const [waveform, setWaveform] = useState("sine");
+  const [waveform, setWaveform] = useState<WaveformType>("sine");
 
   // Tone.Channel properties
   const [volume, setVolume] = useState(-5);
@@ -267,9 +267,9 @@ function Oscillator({
         }}
       />
       <div className="justify-between mt-1">
-        <OptionsSelector
+        <OptionsSelector<WaveformType>
           handleChange={(e) => {
-            const newWaveform = e.target.value;
+            const newWaveform = e.target.value as WaveformType;
             setWaveform(newWaveform);
             onParameterChange?.();
           }}

--- a/src/components/Polysynth.tsx
+++ b/src/components/Polysynth.tsx
@@ -11,6 +11,7 @@ import { useKeyDown } from "../hooks/useKeyDown";
 import { PolySynthHandle, PolySynthParams } from "../types/PolySynthParams";
 import { useRampedParameter } from "../hooks/useRampedParameter";
 import { useDebounceCallback } from "usehooks-ts";
+import { WaveformType } from "../types/OscillatorParams";
 
 interface PolysynthProps {
   polySynth: Tone.PolySynth;
@@ -30,7 +31,7 @@ function PolySynth({
   onParameterChange,
 }: PolysynthProps) {
   const [frequency, setFrequency] = useState(initialParams?.frequency ?? 666);
-  const [waveform, setWaveform] = useState<OscillatorType>(
+  const [waveform, setWaveform] = useState<WaveformType>(
     initialParams?.waveform ?? "sine"
   );
   const [volume, setVolume] = useState(initialParams?.volume ?? -5);
@@ -219,9 +220,9 @@ function PolySynth({
           onParameterChange?.();
         }}
       />
-      <OptionsSelector<OscillatorType>
+      <OptionsSelector<WaveformType>
         handleChange={(e) => {
-          setWaveform(e.target.value as OscillatorType);
+          setWaveform(e.target.value as WaveformType);
           onParameterChange?.();
         }}
         value={waveform}

--- a/src/presets/init.json
+++ b/src/presets/init.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 7,
   "metadata": {
     "id": "factory-init",
     "name": "Init",
@@ -228,7 +228,7 @@
         "Q": 1,
         "wet": 0,
         "type": "highpass",
-        "oscillatorType": "sine"
+        "waveform": "sine"
       },
       "bitCrusher": {
         "bits": 5,

--- a/src/presets/melody-memory.json
+++ b/src/presets/melody-memory.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 7,
   "metadata": {
     "id": "factory-melody-memory",
     "name": "Melody Memory",
@@ -228,7 +228,7 @@
         "Q": 3,
         "wet": 0.5,
         "type": "bandpass",
-        "oscillatorType": "sine"
+        "waveform": "sine"
       },
       "bitCrusher": {
         "bits": 8,

--- a/src/presets/rhythmic-pulsar.json
+++ b/src/presets/rhythmic-pulsar.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 7,
   "metadata": {
     "id": "factory-rhythmic-pulsar",
     "name": "Rhythmic Pulsar",
@@ -228,7 +228,7 @@
         "Q": 5,
         "wet": 0.3,
         "type": "highpass",
-        "oscillatorType": "square"
+        "waveform": "square"
       },
       "bitCrusher": {
         "bits": 4,

--- a/src/presets/the-ending-world.json
+++ b/src/presets/the-ending-world.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 7,
   "metadata": {
     "id": "factory-the-ending-world",
     "name": "The Ending World",
@@ -228,7 +228,7 @@
         "Q": 2,
         "wet": 0.3,
         "type": "lowpass",
-        "oscillatorType": "sine"
+        "waveform": "sine"
       },
       "bitCrusher": {
         "bits": 8,

--- a/src/types/AutoFilterParams.ts
+++ b/src/types/AutoFilterParams.ts
@@ -1,4 +1,5 @@
 import * as Tone from "tone";
+import { WaveformType } from './OscillatorParams';
 
 /**
  * Parameters for the AutoFilter effect that should be persisted in presets
@@ -11,7 +12,7 @@ export interface AutoFilterParams {
   Q: number;
   wet: number;
   type: BiquadFilterType;
-  oscillatorType: OscillatorType;
+  waveform: WaveformType; // LFO waveform for the auto-filter modulation
 }
 
 /**

--- a/src/types/ModulationMatrixParams.ts
+++ b/src/types/ModulationMatrixParams.ts
@@ -1,3 +1,5 @@
+import { WaveformType } from './OscillatorParams';
+
 /**
  * LFO polarity mode
  */
@@ -8,7 +10,7 @@ export type LFOPolarityMode = 'bipolar' | 'unipolar';
  */
 export interface LFOParams {
   frequency: number; // Hz
-  type: OscillatorType; // waveform type
+  type: WaveformType; // waveform shape
   amplitude: number; // 0-1
   polarityMode?: LFOPolarityMode; // bipolar (-1 to +1) or unipolar (0 to +1), defaults to bipolar
 }

--- a/src/types/OscillatorParams.ts
+++ b/src/types/OscillatorParams.ts
@@ -4,11 +4,17 @@
 export type OscillatorType = "basic" | "fat";
 
 /**
+ * Waveform shape for oscillators, LFOs, and other audio sources
+ * Note: This is distinct from the global DOM OscillatorType which includes "custom"
+ */
+export type WaveformType = "sine" | "triangle" | "square" | "sawtooth";
+
+/**
  * Parameters for a single Oscillator component that should be persisted in presets
  */
 export interface OscillatorParams {
   frequency: number;
-  waveform: string; // "sine" | "square" | "triangle" | "sawtooth"
+  waveform: WaveformType;
   volume: number;
   pan: number;
   oscillatorType: OscillatorType;

--- a/src/types/PolySynthParams.ts
+++ b/src/types/PolySynthParams.ts
@@ -1,9 +1,11 @@
+import { WaveformType } from './OscillatorParams';
+
 /**
  * Parameters for a single PolySynth instance
  */
 export interface PolySynthParams {
   frequency: number;
-  waveform: OscillatorType;
+  waveform: WaveformType;
   volume: number;
   pan: number;
   attack: number;

--- a/src/utils/presetDefaults.ts
+++ b/src/utils/presetDefaults.ts
@@ -7,7 +7,7 @@ import type {
   PolySynthParams,
   PolySynthsState,
 } from "../types/PolySynthParams";
-import type { OscillatorParams } from "../types/OscillatorParams";
+import type { OscillatorParams, WaveformType } from "../types/OscillatorParams";
 import type { OscillatorsState } from "../types/OscillatorsParams";
 import type { Sequence } from "../types/Sequence";
 import type { PresetState } from "../types/Preset";
@@ -78,7 +78,7 @@ export const DEFAULT_SYNTH_ENVELOPE_PARAMS: SynthEnvelopeParams = {
 
 export const DEFAULT_POLYSYNTH_PARAMS: PolySynthParams = {
   frequency: 666,
-  waveform: "sine" as OscillatorType,
+  waveform: "sine" as WaveformType,
   volume: -5,
   pan: 0,
   attack: 0.5,
@@ -106,7 +106,7 @@ export const DEFAULT_AUTO_FILTER_PARAMS: AutoFilterParams = {
   Q: 1,
   wet: 0.5,
   type: "lowpass",
-  oscillatorType: "sine",
+  waveform: "sine",
 };
 
 export const DEFAULT_BIT_CRUSHER_PARAMS: BitCrusherParams = {

--- a/src/utils/presetMigration.test.ts
+++ b/src/utils/presetMigration.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./presetMigration";
 import type { Preset, PresetState } from "../types/Preset";
 import { DEFAULT_BPM } from "./presetDefaults";
+import type { WaveformType } from "../types/OscillatorParams";
 
 describe("presetMigration", () => {
   const createV1Preset = (): Preset => ({
@@ -66,7 +67,7 @@ describe("presetMigration", () => {
       },
       effectsBusSend: 0.5,
       // V1 presets don't have BPM - migration will add it
-    } as PresetState,
+    } as unknown as PresetState,
   });
 
   const createV2Preset = (): Preset => ({
@@ -139,7 +140,7 @@ describe("presetMigration", () => {
       },
       effectsBusSend: 0.5,
       // V2 presets don't have BPM - migration will add it
-    } as PresetState,
+    } as unknown as PresetState,
   });
 
   describe("needsMigration", () => {
@@ -167,7 +168,7 @@ describe("presetMigration", () => {
 
     it("should return correct migration path from v2", () => {
       const path = getMigrationPath(2);
-      expect(path).toEqual([2, 3, 4, 5]); // v2→v3, v3→v4, v4→v5, v5→v6
+      expect(path).toEqual([2, 3, 4, 5, 6]); // v2→v3, v3→v4, v4→v5, v5→v6, v6→v7
     });
 
     it("should return empty array for current version", () => {
@@ -193,8 +194,10 @@ describe("presetMigration", () => {
 
         expect(migrated.metadata).toEqual(v1Preset.metadata);
         expect(migrated.state.oscillators).toEqual(v1Preset.state.oscillators);
-        // Effects should be preserved (reverb was removed from app, so not added)
-        expect(migrated.state.effects).toEqual(v1Preset.state.effects);
+        // Effects should be preserved, with autoFilter.oscillatorType renamed to waveform
+        expect(migrated.state.effects.autoFilter.waveform).toBe("sine");
+        expect(migrated.state.effects.bitCrusher).toEqual(v1Preset.state.effects.bitCrusher);
+        expect(migrated.state.effects.chebyshev).toEqual(v1Preset.state.effects.chebyshev);
         expect(migrated.state.effectsBusSend).toBe(
           v1Preset.state.effectsBusSend
         );
@@ -224,7 +227,7 @@ describe("presetMigration", () => {
         const polysynthsWithoutPan = [
           {
             frequency: 666,
-            waveform: "sine" as OscillatorType,
+            waveform: "sine" as WaveformType,
             volume: -5,
             attack: 0.5,
             decay: 0.7,
@@ -233,7 +236,7 @@ describe("presetMigration", () => {
           },
           {
             frequency: 999,
-            waveform: "sine" as OscillatorType,
+            waveform: "sine" as WaveformType,
             volume: -5,
             attack: 0.5,
             decay: 0.7,
@@ -260,7 +263,7 @@ describe("presetMigration", () => {
         const polysynthsWithPan = [
           {
             frequency: 666,
-            waveform: "sine" as OscillatorType,
+            waveform: "sine" as WaveformType,
             volume: -5,
             pan: -0.3,
             attack: 0.5,
@@ -270,7 +273,7 @@ describe("presetMigration", () => {
           },
           {
             frequency: 999,
-            waveform: "sine" as OscillatorType,
+            waveform: "sine" as WaveformType,
             volume: -5,
             pan: 0.3,
             attack: 0.5,
@@ -323,8 +326,9 @@ describe("presetMigration", () => {
         });
         // Second polysynth should be added during v3→v4 migration
         expect(migrated.state.polysynths.polysynths).toHaveLength(2);
-        // Effects should be preserved (reverb was removed from app, so not added)
-        expect(migrated.state.effects).toEqual(v2Preset.state.effects);
+        // Effects should be preserved, with autoFilter.oscillatorType renamed to waveform
+        expect(migrated.state.effects.autoFilter.waveform).toBe("sine");
+        expect(migrated.state.effects.bitCrusher).toEqual(v2Preset.state.effects.bitCrusher);
         expect(migrated.state.effectsBusSend).toBe(
           v2Preset.state.effectsBusSend
         );
@@ -348,8 +352,48 @@ describe("presetMigration", () => {
 
         expect(migrated.metadata).toEqual(v1Preset.metadata);
         expect(migrated.state.oscillators).toEqual(v1Preset.state.oscillators);
-        // Effects should be preserved (reverb was removed from app, so not added)
-        expect(migrated.state.effects).toEqual(v1Preset.state.effects);
+        // Effects should be preserved, with autoFilter.oscillatorType renamed to waveform
+        expect(migrated.state.effects.autoFilter.waveform).toBe("sine");
+        expect(migrated.state.effects.bitCrusher).toEqual(v1Preset.state.effects.bitCrusher);
+      });
+    });
+
+    describe("v6 to v7 migration", () => {
+      it("should rename autoFilter.oscillatorType to autoFilter.waveform", () => {
+        const v6Preset = createV2Preset();
+        v6Preset.version = 6;
+        v6Preset.state.bpm = 120;
+        // Add pan to polysynths to simulate v6 preset
+        v6Preset.state.polysynths.polysynths = [
+          { ...v6Preset.state.polysynths.polysynths[0], pan: 0 },
+          { frequency: 999, waveform: "sine" as WaveformType, volume: -5, pan: 0, attack: 0.5, decay: 0.7, sustain: 1, release: 3 },
+        ];
+
+        const migrated = migratePreset(v6Preset);
+
+        expect(migrated.version).toBe(CURRENT_PRESET_VERSION);
+        expect(migrated.state.effects.autoFilter.waveform).toBe("sine");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        expect((migrated.state.effects.autoFilter as any).oscillatorType).toBeUndefined();
+      });
+
+      it("should preserve waveform value if already present", () => {
+        const v6Preset = createV2Preset();
+        v6Preset.version = 6;
+        v6Preset.state.bpm = 120;
+        v6Preset.state.polysynths.polysynths = [
+          { ...v6Preset.state.polysynths.polysynths[0], pan: 0 },
+          { frequency: 999, waveform: "sine" as WaveformType, volume: -5, pan: 0, attack: 0.5, decay: 0.7, sustain: 1, release: 3 },
+        ];
+        // Preset that somehow already has waveform instead of oscillatorType
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        (v6Preset.state.effects.autoFilter as any).waveform = "square";
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        delete (v6Preset.state.effects.autoFilter as any).oscillatorType;
+
+        const migrated = migratePreset(v6Preset);
+
+        expect(migrated.state.effects.autoFilter.waveform).toBe("square");
       });
     });
 

--- a/src/utils/presetMigration.ts
+++ b/src/utils/presetMigration.ts
@@ -1,4 +1,5 @@
 import type { Preset } from "../types/Preset";
+import type { WaveformType } from "../types/OscillatorParams";
 import {
   DEFAULT_POLYSYNTHS_STATE,
   DEFAULT_BPM,
@@ -7,7 +8,7 @@ import {
 /**
  * Current preset version
  */
-export const CURRENT_PRESET_VERSION = 6;
+export const CURRENT_PRESET_VERSION = 7;
 
 /**
  * Migrate a preset from an older version to the current version
@@ -48,6 +49,9 @@ function runMigration(preset: Preset, fromVersion: number): Preset {
 
     case 5:
       return migrateV5ToV6(preset);
+
+    case 6:
+      return migrateV6ToV7(preset);
 
     default:
       // No migration needed for this version
@@ -149,6 +153,39 @@ function migrateV5ToV6(preset: Preset): Preset {
     state: {
       ...preset.state,
       // Reverb fields in old presets are ignored (reverb removed from app)
+    },
+  };
+}
+
+/**
+ * Migration from version 6 to version 7
+ * Renames autoFilter.oscillatorType to autoFilter.waveform for type clarity
+ * (oscillatorType was confusing because it's actually a waveform type, not basic/fat)
+ */
+function migrateV6ToV7(preset: Preset): Preset {
+  const autoFilter = preset.state.effects.autoFilter;
+
+  // Handle the field rename: oscillatorType -> waveform
+  // Old presets have oscillatorType, new presets have waveform
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+  const waveform: WaveformType = ((autoFilter as any)?.waveform ?? (autoFilter as any)?.oscillatorType ?? "sine") as WaveformType;
+
+  // Create new autoFilter without the old oscillatorType field
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { oscillatorType: _removed, ...restAutoFilter } = autoFilter as typeof autoFilter & { oscillatorType?: string };
+
+  return {
+    ...preset,
+    version: 7,
+    state: {
+      ...preset.state,
+      effects: {
+        ...preset.state.effects,
+        autoFilter: {
+          ...restAutoFilter,
+          waveform,
+        },
+      },
     },
   };
 }

--- a/src/utils/presetSerializer.test.ts
+++ b/src/utils/presetSerializer.test.ts
@@ -82,7 +82,7 @@ describe("presetSerializer", () => {
         Q: 1,
         wet: 0.5,
         type: "lowpass",
-        oscillatorType: "sine",
+        waveform: "sine",
       },
       bitCrusher: {
         bits: 4,
@@ -118,7 +118,7 @@ describe("presetSerializer", () => {
       const name = "Test Preset";
       const preset = createPreset(name, mockPresetState);
 
-      expect(preset.version).toBe(6);
+      expect(preset.version).toBe(7);
       expect(preset.metadata.name).toBe(name);
       expect(preset.metadata.id).toBeTruthy();
       expect(preset.metadata.created).toMatch(/^\d{4}-\d{2}-\d{2}T/);
@@ -187,8 +187,8 @@ describe("presetSerializer", () => {
       const serialized = JSON.stringify(v2Preset);
       const deserialized = deserializePreset(serialized);
 
-      // Should be migrated to v6
-      expect(deserialized.version).toBe(6);
+      // Should be migrated to v7
+      expect(deserialized.version).toBe(7);
       // Should have BPM added with default value
       expect(deserialized.state.bpm).toBe(120);
       // Should have second polysynth added

--- a/src/utils/presetSerializer.ts
+++ b/src/utils/presetSerializer.ts
@@ -5,7 +5,7 @@ import { migratePreset, needsMigration } from "./presetMigration";
  * Current preset format version
  * Increment this when making breaking changes to preset structure
  */
-const CURRENT_VERSION = 6;
+const CURRENT_VERSION = 7;
 
 /**
  * Generate a unique ID for a preset

--- a/src/utils/presetStorage.test.ts
+++ b/src/utils/presetStorage.test.ts
@@ -95,7 +95,7 @@ describe("presetStorage", () => {
         Q: 1,
         wet: 0.5,
         type: "lowpass",
-        oscillatorType: "sine",
+        waveform: "sine",
       },
       bitCrusher: {
         bits: 4,

--- a/src/utils/presetUrl.test.ts
+++ b/src/utils/presetUrl.test.ts
@@ -70,7 +70,7 @@ describe("presetUrl", () => {
         Q: 1,
         wet: 0.5,
         type: "lowpass",
-        oscillatorType: "sine",
+        waveform: "sine",
       },
       bitCrusher: {
         bits: 4,


### PR DESCRIPTION
## Summary

This PR introduces a new explicit `WaveformType` to fix type confusion in the codebase.

### The Problem

Previously, the codebase had two identically-named types with different meanings:
- **Global DOM `OscillatorType`**: `'sine' | 'triangle' | 'square' | 'sawtooth' | 'custom'` (from Web Audio API)
- **Custom `OscillatorType`**: `'basic' | 'fat'` (for oscillator mode)

This was confusing and error-prone, relying on implicit behavior where importing vs not importing determined which type was used.

### The Solution

Introduce a new explicit `WaveformType` for waveform shapes:

```typescript
// Clear distinction between the two concepts:
export type OscillatorType = 'basic' | 'fat';        // Oscillator mode
export type WaveformType = 'sine' | 'triangle' | 'square' | 'sawtooth';  // Waveform shape
```

### Changes

- Add `WaveformType = 'sine' | 'triangle' | 'square' | 'sawtooth'`
- Update `LFOParams.type` to use `WaveformType`
- Update `PolySynthParams.waveform` to use `WaveformType`
- Update `OscillatorParams.waveform` to use `WaveformType` (was `string`)
- Rename `AutoFilterParams.oscillatorType` to `waveform` with `WaveformType`
- Update all components to use proper types
- Add v6→v7 preset migration to rename `autoFilter.oscillatorType` to `waveform`
- Bump preset version to 7
- Update all tests and fixtures

### Testing

- ✅ All 188 unit tests pass
- ✅ Linting passes
- ✅ TypeScript type checking passes

### Backwards Compatibility

A migration (v6→v7) handles existing presets by renaming `autoFilter.oscillatorType` to `autoFilter.waveform`.